### PR TITLE
feat: service account for pods

### DIFF
--- a/api/v1alpha1/workbench_types.go
+++ b/api/v1alpha1/workbench_types.go
@@ -52,6 +52,8 @@ type WorkbenchSpec struct {
 	Server WorkbenchServer `json:"server,omitempty"`
 	// Apps represent a list of applications any their state
 	Apps []WorkbenchApp `json:"apps,omitempty"`
+	// Service Account to be used by the pods.
+	ServiceAccount string `json:"serviceAccountName,omitempty"`
 }
 
 // WorkbenchStatusAppStatus are the effective status of a launched app.

--- a/config/crd/bases/default.chorus-tre.ch_workbenches.yaml
+++ b/config/crd/bases/default.chorus-tre.ch_workbenches.yaml
@@ -76,6 +76,9 @@ spec:
                     description: Version defines the version to use.
                     type: string
                 type: object
+              serviceAccountName:
+                description: Service Account to be used by the pods.
+                type: string
             type: object
           status:
             description: WorkbenchStatus defines the observed state of Workbench

--- a/internal/controller/deployment.go
+++ b/internal/controller/deployment.go
@@ -34,6 +34,12 @@ func initDeployment(workbench defaultv1alpha1.Workbench, config Config) appsv1.D
 	}
 	deployment.Spec.Template.Labels = labels
 
+	// Service account is an alternative to the image Pull Secrets
+	serviceAccountName := workbench.Spec.ServiceAccount
+	if serviceAccountName != "" {
+		deployment.Spec.Template.Spec.ServiceAccountName = serviceAccountName
+	}
+
 	// Shared by the containers
 	volume := corev1.Volume{
 		Name: "x11-unix",

--- a/internal/controller/job.go
+++ b/internal/controller/job.go
@@ -24,6 +24,12 @@ func initJob(workbench defaultv1alpha1.Workbench, config Config, index int, app 
 
 	job.Labels = labels
 
+	// Service account is an alternative to the image Pull Secrets
+	serviceAccountName := workbench.Spec.ServiceAccount
+	if serviceAccountName != "" {
+		job.Spec.Template.Spec.ServiceAccountName = serviceAccountName
+	}
+
 	// Fix empty version
 	appVersion := app.Version
 	if appVersion == "" {

--- a/internal/controller/workbench_controller_test.go
+++ b/internal/controller/workbench_controller_test.go
@@ -35,6 +35,8 @@ var _ = Describe("Workbench Controller", func() {
 			},
 		}
 
+		workbench.Spec.ServiceAccount = "service-account"
+
 		workbench.Spec.Apps = []defaultv1alpha1.WorkbenchApp{
 			{
 				Name: "wezterm",
@@ -93,6 +95,8 @@ var _ = Describe("Workbench Controller", func() {
 			Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(HavePrefix("my-registry/"))
 			Expect(deployment.Spec.Template.Spec.InitContainers[0].Image).To(HavePrefix("alpine/socat:"))
 
+			Expect(deployment.Spec.Template.Spec.ServiceAccountName).To(Equal("service-account"))
+
 			// Verify that a service exists
 			service := &corev1.Service{}
 			err = k8sClient.Get(ctx, typeNamespacedName, service)
@@ -113,6 +117,8 @@ var _ = Describe("Workbench Controller", func() {
 			Expect(job.Spec.Template.Spec.Containers).To(HaveLen(1))
 
 			Expect(job.Spec.Template.Spec.Containers[0].Image).To(HavePrefix("my-registry/"))
+
+			Expect(job.Spec.Template.Spec.ServiceAccountName).To(Equal("service-account"))
 		})
 	})
 })


### PR DESCRIPTION
They can be used as a better way to manage the imagePullSecrets, which are clunky.