### PR TITLE
chore: bump helmify to 0.4.16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ KUSTOMIZE_VERSION ?= v5.4.3
 CONTROLLER_TOOLS_VERSION ?= v0.16.0
 ENVTEST_VERSION ?= release-0.19
 GOLANGCI_LINT_VERSION ?= v1.61.0
-HELMIFY_VERSION ?= v0.4.14
+HELMIFY_VERSION ?= v0.4.15
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.

--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ KUSTOMIZE_VERSION ?= v5.4.3
 CONTROLLER_TOOLS_VERSION ?= v0.16.0
 ENVTEST_VERSION ?= release-0.19
 GOLANGCI_LINT_VERSION ?= v1.61.0
-HELMIFY_VERSION ?= v0.4.15
+HELMIFY_VERSION ?= v0.4.16
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.

--- a/charts/workbench-operator/templates/metrics-service.yaml
+++ b/charts/workbench-operator/templates/metrics-service.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "workbench-operator.fullname" . }}-metrics-service
+  name: {{ include "workbench-operator.fullname" . }}-controller-manager-metrics-service
   labels:
     control-plane: controller-manager
-    {{- include "workbench-operator.labels" . | nindent 4 }}
+  {{- include "workbench-operator.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.metricsService.type }}
   selector:


### PR DESCRIPTION
The wild tab has been fixed there: https://github.com/arttor/helmify/releases/tag/v0.4.15

https://github.com/arttor/helmify/releases/tag/v0.4.16