### PR TITLE
fix : Revert default resources

### DIFF
--- a/charts/workbench-operator/Chart.yaml
+++ b/charts/workbench-operator/Chart.yaml
@@ -22,9 +22,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.7
+version: 0.3.8
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.3.7"
+appVersion: "0.3.8"

--- a/charts/workbench-operator/values.yaml
+++ b/charts/workbench-operator/values.yaml
@@ -15,7 +15,7 @@ controllerManager:
         - ALL
     image:
       repository: harbor.build.chorus-tre.local/chorus/workbench-operator
-      tag: 0.3.7
+      tag: 0.3.8
     resources:
       limits:
         cpu: 500m

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
   - name: controller
     newName: harbor.chorus-tre.local/chorus/workbench-operator
-    newTag: 0.3.7
+    newTag: 0.3.8

--- a/internal/controller/job.go
+++ b/internal/controller/job.go
@@ -18,12 +18,12 @@ import (
 var defaultResources = corev1.ResourceRequirements{
 	Limits: corev1.ResourceList{
 		corev1.ResourceCPU:              resource.MustParse("750m"),
-		corev1.ResourceMemory:           resource.MustParse("1536Mi"),
+		corev1.ResourceMemory:           resource.MustParse("768Mi"),
 		corev1.ResourceEphemeralStorage: resource.MustParse("10Gi"),
 	},
 	Requests: corev1.ResourceList{
 		corev1.ResourceCPU:              resource.MustParse("500m"),
-		corev1.ResourceMemory:           resource.MustParse("1024Mi"),
+		corev1.ResourceMemory:           resource.MustParse("512Mi"),
 		corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
 	},
 }


### PR DESCRIPTION
brainstorm needed more cpu as well as more memory so until limits are implemented in the backend we'll remove apps that need too much ressources in order to prevent overloading the cluster during development 