### PR TITLE
feat: Remove default resources

### DIFF
--- a/charts/workbench-operator/Chart.yaml
+++ b/charts/workbench-operator/Chart.yaml
@@ -22,9 +22,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.14
+version: 0.3.15
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.3.14"
+appVersion: "0.3.15"

--- a/charts/workbench-operator/values.yaml
+++ b/charts/workbench-operator/values.yaml
@@ -15,7 +15,7 @@ controllerManager:
         - ALL
     image:
       repository: harbor.build.chorus-tre.local/chorus/workbench-operator
-      tag: 0.3.14
+      tag: 0.3.15
     resources:
       limits:
         cpu: 500m

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
   - name: controller
     newName: harbor.chorus-tre.local/chorus/workbench-operator
-    newTag: 0.3.14
+    newTag: 0.3.15

--- a/config/samples/default_v1alpha1_workbench.yaml
+++ b/config/samples/default_v1alpha1_workbench.yaml
@@ -9,9 +9,11 @@ spec:
   server:
     version: "6.2.1-1"
   apps:
-    - name: jupyterlab
+    jlab:
+      name: jupyterlab
       version: "4.2.5-1"
       shmSize: 1Gi
-    - name: wezterm
+    terminal:
+      name: wezterm
       version: "0.0.1"
       state: Stopped

--- a/internal/controller/job.go
+++ b/internal/controller/job.go
@@ -7,21 +7,11 @@ import (
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	defaultv1alpha1 "github.com/CHORUS-TRE/workbench-operator/api/v1alpha1"
 )
-
-// Default resource requirements for workbench applications
-var defaultResources = corev1.ResourceRequirements{
-	Limits: corev1.ResourceList{
-		corev1.ResourceCPU:              resource.MustParse("150m"),
-		corev1.ResourceMemory:           resource.MustParse("192Mi"),
-		corev1.ResourceEphemeralStorage: resource.MustParse("10Gi"),
-	},
-}
 
 func initJob(workbench defaultv1alpha1.Workbench, config Config, uid string, app defaultv1alpha1.WorkbenchApp, service corev1.Service) *batchv1.Job {
 	job := &batchv1.Job{}
@@ -100,7 +90,6 @@ func initJob(workbench defaultv1alpha1.Workbench, config Config, uid string, app
 		Name:            app.Name,
 		Image:           appImage,
 		ImagePullPolicy: imagePullPolicy,
-		Resources:       defaultResources, // Set default resources
 		Env: []corev1.EnvVar{
 			{
 				Name:  "DISPLAY",


### PR DESCRIPTION
Since limits and requests are now implemented in the backend and the UI on dev we remove the default resources to allow reusing apps like brainstorm in QA until everything is validated and propagated.
Also update defaut_v1alpha1_workbench.yaml to use map instead of list since [#69](https://github.com/CHORUS-TRE/workbench-operator/pull/69)