### PR TITLE
fix nfs inline mount

### DIFF
--- a/charts/workbench-operator/Chart.yaml
+++ b/charts/workbench-operator/Chart.yaml
@@ -22,9 +22,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.43
+version: 0.3.44
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.3.43"
+appVersion: "0.3.44"

--- a/charts/workbench-operator/values.yaml
+++ b/charts/workbench-operator/values.yaml
@@ -29,7 +29,7 @@ controllerManager:
         - ALL
     image:
       repository: harbor.build.chorus-tre.local/chorus/workbench-operator
-      tag: 0.3.43
+      tag: 0.3.44
     resources:
       limits:
         cpu: 500m

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
   - name: controller
     newName: harbor.chorus-tre.local/chorus/workbench-operator
-    newTag: 0.3.43
+    newTag: 0.3.44

--- a/internal/controller/storage.go
+++ b/internal/controller/storage.go
@@ -607,12 +607,9 @@ func (n *NFSProvider) Setup(ctx context.Context, workbench defaultv1alpha1.Workb
 						{
 							Name: "nfs-volume",
 							VolumeSource: corev1.VolumeSource{
-								CSI: &corev1.CSIVolumeSource{
-									Driver: n.GetDriverName(),
-									VolumeAttributes: map[string]string{
-										"server": server,
-										"share":  share,
-									},
+								NFS: &corev1.NFSVolumeSource{
+									Server: server,
+									Path:   share,
 								},
 							},
 						},


### PR DESCRIPTION
Fixes:
43s (x9 over 2m51s)   Warning   FailedMount         Pod/nfs-mkdir-workspace125-s8w8w            MountVolume.SetUp failed for volume "nfs-volume" : [kubernetes.io/csi](https://kubernetes.io/csi): mounter.SetupAt failed to check volume lifecycle mode: volume mode "Ephemeral" not supported by driver [nfs.csi.k8s.io](https://nfs.csi.k8s.io/) (only supports ["Persistent"])