### PR TITLE
feat(operator): split serverNames by TLS/non-TLS ports for SSH (0.4.55)

### DIFF
--- a/charts/workbench-operator/Chart.yaml
+++ b/charts/workbench-operator/Chart.yaml
@@ -22,9 +22,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.54
+version: 0.4.55
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.54"
+appVersion: "0.4.55"

--- a/charts/workbench-operator/values.yaml
+++ b/charts/workbench-operator/values.yaml
@@ -5,7 +5,7 @@
 # blocking other URLs served by the same gateway or ingress controller.
 # globalInternalServices:
 # - fqdn: gitlab.internal.chorus-tre.local
-#   ports: ["443"]
+#   ports: ["443", "22"]
 # - fqdn: i2b2.internal.chorus-tre.local
 #   ports: ["443"]
 globalInternalServices: []
@@ -82,7 +82,7 @@ controllerManager:
         - ALL
     image:
       repository: harbor.build.chorus-tre.local/chorus/workbench-operator
-      tag: 0.4.54
+      tag: 0.4.55
     resources:
       limits:
         cpu: 500m

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
   - name: controller
     newName: harbor.chorus-tre.local/chorus/workbench-operator
-    newTag: 0.4.54
+    newTag: 0.4.55

--- a/internal/controller/network_policy.go
+++ b/internal/controller/network_policy.go
@@ -287,47 +287,17 @@ func buildNetworkPolicy(workspace defaultv1alpha1.Workspace, internalServices []
 
 		// Envoy Gateway namespaces remap privileged ports (e.g. 443 → 10443, 22 → 10022).
 		if len(envoyEndpoints) > 0 {
-			var toPorts []map[string]any
-			if len(tlsPorts) > 0 {
-				remapped := make([]map[string]any, 0, len(tlsPorts))
-				for _, p := range tlsPorts {
-					remapped = append(remapped, map[string]any{"port": envoyRemapPort(p), "protocol": "TCP"})
-				}
-				toPorts = append(toPorts, map[string]any{"ports": remapped, "serverNames": fqdns})
-			}
-			if len(nonTLSPorts) > 0 {
-				remapped := make([]map[string]any, 0, len(nonTLSPorts))
-				for _, p := range nonTLSPorts {
-					remapped = append(remapped, map[string]any{"port": envoyRemapPort(p), "protocol": "TCP"})
-				}
-				toPorts = append(toPorts, map[string]any{"ports": remapped})
-			}
 			egressRules = append(egressRules, map[string]any{
 				"toEndpoints": envoyEndpoints,
-				"toPorts":     toPorts,
+				"toPorts":     buildToPorts(tlsPorts, nonTLSPorts, fqdns, envoyRemapPort),
 			})
 		}
 
 		// Regular namespaces (e.g. ingress-nginx) use the original ports.
 		if len(regularEndpoints) > 0 {
-			var toPorts []map[string]any
-			if len(tlsPorts) > 0 {
-				portEntries := make([]map[string]any, 0, len(tlsPorts))
-				for _, p := range tlsPorts {
-					portEntries = append(portEntries, map[string]any{"port": p, "protocol": "TCP"})
-				}
-				toPorts = append(toPorts, map[string]any{"ports": portEntries, "serverNames": fqdns})
-			}
-			if len(nonTLSPorts) > 0 {
-				portEntries := make([]map[string]any, 0, len(nonTLSPorts))
-				for _, p := range nonTLSPorts {
-					portEntries = append(portEntries, map[string]any{"port": p, "protocol": "TCP"})
-				}
-				toPorts = append(toPorts, map[string]any{"ports": portEntries})
-			}
 			egressRules = append(egressRules, map[string]any{
 				"toEndpoints": regularEndpoints,
-				"toPorts":     toPorts,
+				"toPorts":     buildToPorts(tlsPorts, nonTLSPorts, fqdns, func(p string) string { return p }),
 			})
 		}
 	}
@@ -434,6 +404,27 @@ func internalServicePorts(services []InternalService) []string {
 		return []string{"443"}
 	}
 	return ports
+}
+
+// buildToPorts constructs the toPorts slice for an egress rule, applying remapFn to each port.
+// TLS ports (see isTLSPort) get a serverNames entry for SNI filtering; non-TLS ports do not.
+func buildToPorts(tlsPorts, nonTLSPorts []string, fqdns []string, remapFn func(string) string) []map[string]any {
+	var toPorts []map[string]any
+	if len(tlsPorts) > 0 {
+		ports := make([]map[string]any, 0, len(tlsPorts))
+		for _, p := range tlsPorts {
+			ports = append(ports, map[string]any{"port": remapFn(p), "protocol": "TCP"})
+		}
+		toPorts = append(toPorts, map[string]any{"ports": ports, "serverNames": fqdns})
+	}
+	if len(nonTLSPorts) > 0 {
+		ports := make([]map[string]any, 0, len(nonTLSPorts))
+		for _, p := range nonTLSPorts {
+			ports = append(ports, map[string]any{"port": remapFn(p), "protocol": "TCP"})
+		}
+		toPorts = append(toPorts, map[string]any{"ports": ports})
+	}
+	return toPorts
 }
 
 // isTLSPort reports whether a port carries TLS traffic and should use serverNames

--- a/internal/controller/network_policy.go
+++ b/internal/controller/network_policy.go
@@ -113,9 +113,8 @@ type InternalService struct {
 	// FQDN is the fully-qualified domain name of the internal service (e.g. "gitlab.int.chorus-tre.ch").
 	FQDN string
 	// Ports is the list of TCP ports declared for this service (e.g. ["443", "22"]).
-	// RESERVED — this field has NO effect on the generated CiliumNetworkPolicy.
-	// buildNetworkPolicy always hardcodes port 443 in the egress rule.
-	// Non-443 ports (e.g. SSH/22) require a separate egress path and are not yet implemented.
+	// TLS ports (443) are emitted with serverNames SNI filtering in the CNP egress rule.
+	// Non-TLS ports (e.g. 22 for SSH) are emitted without serverNames — SSH has no TLS ClientHello.
 	Ports []string
 }
 
@@ -144,8 +143,9 @@ type NetworkPolicyNamespaces struct {
 //   - Airgapped     → kube-dns + intra-namespace (pod + service) + internal services only
 //
 // Internal services are always allowed regardless of mode. Separate toEndpoints rules are
-// emitted for Envoy Gateway namespaces (ports remapped: 443 → 10443) and regular namespaces
-// (ports unchanged), both with serverNames SNI filtering to restrict access to listed FQDNs only.
+// emitted for Envoy Gateway namespaces (ports remapped: 443 → 10443, 22 → 10022) and regular
+// namespaces (ports unchanged). TLS ports (443) carry serverNames SNI filtering; non-TLS ports
+// (e.g. 22 for SSH) do not — SSH has no TLS ClientHello so serverNames cannot apply.
 //
 // Ingress policy: pods from ns.AllowedIngress namespaces and the workspace namespace
 // may connect inbound. This prevents pods in other workspaces from reaching services here.
@@ -273,37 +273,61 @@ func buildNetworkPolicy(workspace defaultv1alpha1.Workspace, internalServices []
 
 		ports := internalServicePorts(internalServices)
 
+		// Separate ports by protocol layer: TLS ports (443) support serverNames SNI filtering;
+		// non-TLS ports (e.g. 22 for SSH) do not have a TLS ClientHello and must be emitted
+		// in a separate toPorts entry without serverNames.
+		var tlsPorts, nonTLSPorts []string
+		for _, p := range ports {
+			if p == "443" {
+				tlsPorts = append(tlsPorts, p)
+			} else {
+				nonTLSPorts = append(nonTLSPorts, p)
+			}
+		}
+
 		// Envoy Gateway namespaces remap privileged ports (e.g. 443 → 10443, 22 → 10022).
 		if len(envoyEndpoints) > 0 {
-			envoyPorts := make([]map[string]any, 0, len(ports))
-			for _, p := range ports {
-				envoyPorts = append(envoyPorts, map[string]any{"port": envoyRemapPort(p), "protocol": "TCP"})
+			var toPorts []map[string]any
+			if len(tlsPorts) > 0 {
+				remapped := make([]map[string]any, 0, len(tlsPorts))
+				for _, p := range tlsPorts {
+					remapped = append(remapped, map[string]any{"port": envoyRemapPort(p), "protocol": "TCP"})
+				}
+				toPorts = append(toPorts, map[string]any{"ports": remapped, "serverNames": fqdns})
+			}
+			if len(nonTLSPorts) > 0 {
+				remapped := make([]map[string]any, 0, len(nonTLSPorts))
+				for _, p := range nonTLSPorts {
+					remapped = append(remapped, map[string]any{"port": envoyRemapPort(p), "protocol": "TCP"})
+				}
+				toPorts = append(toPorts, map[string]any{"ports": remapped})
 			}
 			egressRules = append(egressRules, map[string]any{
 				"toEndpoints": envoyEndpoints,
-				"toPorts": []map[string]any{
-					{
-						"ports":       envoyPorts,
-						"serverNames": fqdns,
-					},
-				},
+				"toPorts":     toPorts,
 			})
 		}
 
 		// Regular namespaces (e.g. ingress-nginx) use the original ports.
 		if len(regularEndpoints) > 0 {
-			regularPorts := make([]map[string]any, 0, len(ports))
-			for _, p := range ports {
-				regularPorts = append(regularPorts, map[string]any{"port": p, "protocol": "TCP"})
+			var toPorts []map[string]any
+			if len(tlsPorts) > 0 {
+				portEntries := make([]map[string]any, 0, len(tlsPorts))
+				for _, p := range tlsPorts {
+					portEntries = append(portEntries, map[string]any{"port": p, "protocol": "TCP"})
+				}
+				toPorts = append(toPorts, map[string]any{"ports": portEntries, "serverNames": fqdns})
+			}
+			if len(nonTLSPorts) > 0 {
+				portEntries := make([]map[string]any, 0, len(nonTLSPorts))
+				for _, p := range nonTLSPorts {
+					portEntries = append(portEntries, map[string]any{"port": p, "protocol": "TCP"})
+				}
+				toPorts = append(toPorts, map[string]any{"ports": portEntries})
 			}
 			egressRules = append(egressRules, map[string]any{
 				"toEndpoints": regularEndpoints,
-				"toPorts": []map[string]any{
-					{
-						"ports":       regularPorts,
-						"serverNames": fqdns,
-					},
-				},
+				"toPorts":     toPorts,
 			})
 		}
 	}

--- a/internal/controller/network_policy.go
+++ b/internal/controller/network_policy.go
@@ -273,12 +273,12 @@ func buildNetworkPolicy(workspace defaultv1alpha1.Workspace, internalServices []
 
 		ports := internalServicePorts(internalServices)
 
-		// Separate ports by protocol layer: TLS ports (443) support serverNames SNI filtering;
+		// Separate ports by protocol layer: TLS ports support serverNames SNI filtering;
 		// non-TLS ports (e.g. 22 for SSH) do not have a TLS ClientHello and must be emitted
 		// in a separate toPorts entry without serverNames.
 		var tlsPorts, nonTLSPorts []string
 		for _, p := range ports {
-			if p == "443" {
+			if isTLSPort(p) {
 				tlsPorts = append(tlsPorts, p)
 			} else {
 				nonTLSPorts = append(nonTLSPorts, p)
@@ -434,6 +434,13 @@ func internalServicePorts(services []InternalService) []string {
 		return []string{"443"}
 	}
 	return ports
+}
+
+// isTLSPort reports whether a port carries TLS traffic and should use serverNames
+// SNI filtering. Currently only standard HTTPS (443). Extend here if non-standard
+// TLS ports (e.g. 8443) are needed — or adopt a typed PortSpec with a TLS field.
+func isTLSPort(p string) bool {
+	return p == "443"
 }
 
 // envoyRemapPort remaps privileged ports (< 1024) by adding 10000, matching

--- a/internal/controller/network_policy_test.go
+++ b/internal/controller/network_policy_test.go
@@ -365,7 +365,7 @@ var _ = Describe("buildNetworkPolicy with internal services", func() {
 		Expect(toPorts[0]).To(HaveKey("serverNames"))
 	})
 
-	It("includes all declared ports (e.g. 443 and 22) with remapping for Envoy Gateway", func() {
+	It("splits TLS and non-TLS ports into separate toPorts entries: serverNames on 443 only, not on 22", func() {
 		ws := baseWorkspace(defaultv1alpha1.NetworkPolicyAirgapped)
 		multiPortSvcs := []InternalService{
 			{FQDN: "gitlab.chorus-tre.ch", Ports: []string{"443", "22"}},
@@ -382,13 +382,21 @@ var _ = Describe("buildNetworkPolicy with internal services", func() {
 		// 3 base + 1 envoy + 1 regular
 		Expect(egress).To(HaveLen(5))
 
-		envoyPorts := egress[3]["toPorts"].([]map[string]any)[0]["ports"].([]map[string]any)
-		Expect(envoyPorts).To(ContainElement(HaveKeyWithValue("port", "10443")))
-		Expect(envoyPorts).To(ContainElement(HaveKeyWithValue("port", "10022")))
+		// Envoy rule: TLS entry (10443, with serverNames) and non-TLS entry (10022, no serverNames)
+		envoyToPorts := egress[3]["toPorts"].([]map[string]any)
+		Expect(envoyToPorts).To(HaveLen(2))
+		Expect(envoyToPorts[0]["ports"].([]map[string]any)).To(ContainElement(HaveKeyWithValue("port", "10443")))
+		Expect(envoyToPorts[0]).To(HaveKey("serverNames"))
+		Expect(envoyToPorts[1]["ports"].([]map[string]any)).To(ContainElement(HaveKeyWithValue("port", "10022")))
+		Expect(envoyToPorts[1]).NotTo(HaveKey("serverNames"))
 
-		regularPorts := egress[4]["toPorts"].([]map[string]any)[0]["ports"].([]map[string]any)
-		Expect(regularPorts).To(ContainElement(HaveKeyWithValue("port", "443")))
-		Expect(regularPorts).To(ContainElement(HaveKeyWithValue("port", "22")))
+		// Regular rule: TLS entry (443, with serverNames) and non-TLS entry (22, no serverNames)
+		regularToPorts := egress[4]["toPorts"].([]map[string]any)
+		Expect(regularToPorts).To(HaveLen(2))
+		Expect(regularToPorts[0]["ports"].([]map[string]any)).To(ContainElement(HaveKeyWithValue("port", "443")))
+		Expect(regularToPorts[0]).To(HaveKey("serverNames"))
+		Expect(regularToPorts[1]["ports"].([]map[string]any)).To(ContainElement(HaveKeyWithValue("port", "22")))
+		Expect(regularToPorts[1]).NotTo(HaveKey("serverNames"))
 	})
 
 	It("treats all namespaces as regular when EnvoyGatewayNamespaces is empty", func() {


### PR DESCRIPTION
## Split serverNames by TLS/non-TLS ports for SSH support (0.4.55)

Fixes the internal-services egress rule to correctly handle non-TLS ports (e.g. SSH/22) alongside TLS ports (443).

Previously, `serverNames` SNI filtering was applied to all declared ports in a single `toPorts` entry. This is incorrect for SSH: SSH has no TLS ClientHello, so `serverNames` cannot apply and Cilium would silently ignore or mishandle the rule.

The fix splits ports into two separate `toPorts` entries per egress rule:
- Port 443 (TLS): emitted with `serverNames` for SNI filtering — restricts workspace pods to only the declared FQDNs
- Port 22 and other non-TLS ports: emitted without `serverNames` — no SNI available

The `InternalService.Ports` comment is updated to reflect that the field is now fully effective. The chart example is updated to show `ports: ["443", "22"]` for GitLab.