### PR TITLE
refactor(operator): split TLS and non-TLS ports into separate egress rules (0.4.56)

### DIFF
--- a/charts/workbench-operator/Chart.yaml
+++ b/charts/workbench-operator/Chart.yaml
@@ -22,9 +22,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.55
+version: 0.4.56
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.55"
+appVersion: "0.4.56"

--- a/charts/workbench-operator/values.yaml
+++ b/charts/workbench-operator/values.yaml
@@ -82,7 +82,7 @@ controllerManager:
         - ALL
     image:
       repository: harbor.build.chorus-tre.local/chorus/workbench-operator
-      tag: 0.4.55
+      tag: 0.4.56
     resources:
       limits:
         cpu: 500m

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
   - name: controller
     newName: harbor.chorus-tre.local/chorus/workbench-operator
-    newTag: 0.4.55
+    newTag: 0.4.56

--- a/internal/controller/network_policy.go
+++ b/internal/controller/network_policy.go
@@ -286,19 +286,29 @@ func buildNetworkPolicy(workspace defaultv1alpha1.Workspace, internalServices []
 		}
 
 		// Envoy Gateway namespaces remap privileged ports (e.g. 443 → 10443, 22 → 10022).
+		// TLS and non-TLS ports MUST be in separate egress rules. Cilium applies the L7
+		// proxy (serverNames SNI filtering) to ALL toPorts entries within a single rule —
+		// mixing TLS ports (with serverNames) and non-TLS ports (without) in one rule
+		// can cause the L7 proxy to be mis-applied to non-TLS ports, breaking protocols
+		// like SSH that have no TLS ClientHello.
 		if len(envoyEndpoints) > 0 {
-			egressRules = append(egressRules, map[string]any{
-				"toEndpoints": envoyEndpoints,
-				"toPorts":     buildToPorts(tlsPorts, nonTLSPorts, fqdns, envoyRemapPort),
-			})
+			if len(tlsPorts) > 0 {
+				egressRules = append(egressRules, buildEgressRule(envoyEndpoints, tlsPorts, fqdns, envoyRemapPort))
+			}
+			if len(nonTLSPorts) > 0 {
+				egressRules = append(egressRules, buildEgressRule(envoyEndpoints, nonTLSPorts, nil, envoyRemapPort))
+			}
 		}
 
 		// Regular namespaces (e.g. ingress-nginx) use the original ports.
 		if len(regularEndpoints) > 0 {
-			egressRules = append(egressRules, map[string]any{
-				"toEndpoints": regularEndpoints,
-				"toPorts":     buildToPorts(tlsPorts, nonTLSPorts, fqdns, func(p string) string { return p }),
-			})
+			identityFn := func(p string) string { return p }
+			if len(tlsPorts) > 0 {
+				egressRules = append(egressRules, buildEgressRule(regularEndpoints, tlsPorts, fqdns, identityFn))
+			}
+			if len(nonTLSPorts) > 0 {
+				egressRules = append(egressRules, buildEgressRule(regularEndpoints, nonTLSPorts, nil, identityFn))
+			}
 		}
 	}
 
@@ -406,25 +416,22 @@ func internalServicePorts(services []InternalService) []string {
 	return ports
 }
 
-// buildToPorts constructs the toPorts slice for an egress rule, applying remapFn to each port.
-// TLS ports (see isTLSPort) get a serverNames entry for SNI filtering; non-TLS ports do not.
-func buildToPorts(tlsPorts, nonTLSPorts []string, fqdns []string, remapFn func(string) string) []map[string]any {
-	var toPorts []map[string]any
-	if len(tlsPorts) > 0 {
-		ports := make([]map[string]any, 0, len(tlsPorts))
-		for _, p := range tlsPorts {
-			ports = append(ports, map[string]any{"port": remapFn(p), "protocol": "TCP"})
-		}
-		toPorts = append(toPorts, map[string]any{"ports": ports, "serverNames": fqdns})
+// buildEgressRule constructs a single egress rule for the given endpoints and ports.
+// If fqdns is non-nil, serverNames SNI filtering is added to the toPorts entry.
+// remapFn transforms each port (e.g. envoyRemapPort for Envoy Gateway namespaces).
+func buildEgressRule(endpoints []map[string]any, ports []string, fqdns []string, remapFn func(string) string) map[string]any {
+	portEntries := make([]map[string]any, 0, len(ports))
+	for _, p := range ports {
+		portEntries = append(portEntries, map[string]any{"port": remapFn(p), "protocol": "TCP"})
 	}
-	if len(nonTLSPorts) > 0 {
-		ports := make([]map[string]any, 0, len(nonTLSPorts))
-		for _, p := range nonTLSPorts {
-			ports = append(ports, map[string]any{"port": remapFn(p), "protocol": "TCP"})
-		}
-		toPorts = append(toPorts, map[string]any{"ports": ports})
+	toPortsEntry := map[string]any{"ports": portEntries}
+	if len(fqdns) > 0 {
+		toPortsEntry["serverNames"] = fqdns
 	}
-	return toPorts
+	return map[string]any{
+		"toEndpoints": endpoints,
+		"toPorts":     []map[string]any{toPortsEntry},
+	}
 }
 
 // isTLSPort reports whether a port carries TLS traffic and should use serverNames

--- a/internal/controller/network_policy_test.go
+++ b/internal/controller/network_policy_test.go
@@ -365,7 +365,7 @@ var _ = Describe("buildNetworkPolicy with internal services", func() {
 		Expect(toPorts[0]).To(HaveKey("serverNames"))
 	})
 
-	It("splits TLS and non-TLS ports into separate toPorts entries: serverNames on 443 only, not on 22", func() {
+	It("splits TLS and non-TLS ports into separate egress rules: serverNames on 443 only, not on 22", func() {
 		ws := baseWorkspace(defaultv1alpha1.NetworkPolicyAirgapped)
 		multiPortSvcs := []InternalService{
 			{FQDN: "gitlab.chorus-tre.ch", Ports: []string{"443", "22"}},
@@ -379,24 +379,32 @@ var _ = Describe("buildNetworkPolicy with internal services", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		egress := cnp.Object["spec"].(map[string]any)["egress"].([]map[string]any)
-		// 3 base + 1 envoy + 1 regular
-		Expect(egress).To(HaveLen(5))
+		// 3 base + 2 envoy (TLS + non-TLS) + 2 regular (TLS + non-TLS)
+		Expect(egress).To(HaveLen(7))
 
-		// Envoy rule: TLS entry (10443, with serverNames) and non-TLS entry (10022, no serverNames)
-		envoyToPorts := egress[3]["toPorts"].([]map[string]any)
-		Expect(envoyToPorts).To(HaveLen(2))
-		Expect(envoyToPorts[0]["ports"].([]map[string]any)).To(ContainElement(HaveKeyWithValue("port", "10443")))
-		Expect(envoyToPorts[0]).To(HaveKey("serverNames"))
-		Expect(envoyToPorts[1]["ports"].([]map[string]any)).To(ContainElement(HaveKeyWithValue("port", "10022")))
-		Expect(envoyToPorts[1]).NotTo(HaveKey("serverNames"))
+		// Envoy TLS rule (10443, with serverNames)
+		envoyTLSToPorts := egress[3]["toPorts"].([]map[string]any)
+		Expect(envoyTLSToPorts).To(HaveLen(1))
+		Expect(envoyTLSToPorts[0]["ports"].([]map[string]any)).To(ContainElement(HaveKeyWithValue("port", "10443")))
+		Expect(envoyTLSToPorts[0]).To(HaveKey("serverNames"))
 
-		// Regular rule: TLS entry (443, with serverNames) and non-TLS entry (22, no serverNames)
-		regularToPorts := egress[4]["toPorts"].([]map[string]any)
-		Expect(regularToPorts).To(HaveLen(2))
-		Expect(regularToPorts[0]["ports"].([]map[string]any)).To(ContainElement(HaveKeyWithValue("port", "443")))
-		Expect(regularToPorts[0]).To(HaveKey("serverNames"))
-		Expect(regularToPorts[1]["ports"].([]map[string]any)).To(ContainElement(HaveKeyWithValue("port", "22")))
-		Expect(regularToPorts[1]).NotTo(HaveKey("serverNames"))
+		// Envoy non-TLS rule (10022, no serverNames)
+		envoyNonTLSToPorts := egress[4]["toPorts"].([]map[string]any)
+		Expect(envoyNonTLSToPorts).To(HaveLen(1))
+		Expect(envoyNonTLSToPorts[0]["ports"].([]map[string]any)).To(ContainElement(HaveKeyWithValue("port", "10022")))
+		Expect(envoyNonTLSToPorts[0]).NotTo(HaveKey("serverNames"))
+
+		// Regular TLS rule (443, with serverNames)
+		regularTLSToPorts := egress[5]["toPorts"].([]map[string]any)
+		Expect(regularTLSToPorts).To(HaveLen(1))
+		Expect(regularTLSToPorts[0]["ports"].([]map[string]any)).To(ContainElement(HaveKeyWithValue("port", "443")))
+		Expect(regularTLSToPorts[0]).To(HaveKey("serverNames"))
+
+		// Regular non-TLS rule (22, no serverNames)
+		regularNonTLSToPorts := egress[6]["toPorts"].([]map[string]any)
+		Expect(regularNonTLSToPorts).To(HaveLen(1))
+		Expect(regularNonTLSToPorts[0]["ports"].([]map[string]any)).To(ContainElement(HaveKeyWithValue("port", "22")))
+		Expect(regularNonTLSToPorts[0]).NotTo(HaveKey("serverNames"))
 	})
 
 	It("treats all namespaces as regular when EnvoyGatewayNamespaces is empty", func() {


### PR DESCRIPTION
## Split TLS/non-TLS into separate egress rules

The operator was generating a single egress rule with two `toPorts` entries — one with `serverNames` (TLS/SNI filtering for port 443) and one without (for non-TLS ports like SSH port 22). While Cilium processes each `toPorts` entry independently (each port gets its own `L4Filter` keyed by port+protocol in `pkg/policy/l4.go`), mixing TLS and non-TLS ports in the same rule makes the policy harder to read and reason about.

Splitting them into separate egress rules makes the intent explicit: TLS ports carry `serverNames` SNI filtering, non-TLS ports do not.

- Split into separate egress rules per port category (TLS vs non-TLS)
- Replace `buildToPorts` helper with `buildEgressRule` that constructs a complete egress rule
- Applies to both Envoy Gateway namespaces (remapped ports) and regular namespaces (original ports)

Before (one rule, two toPorts entries):
```yaml
- toEndpoints: [envoy-gateway-system]
  toPorts:
  - ports: [{port: "10443"}]
    serverNames: [gitlab.internal...]
  - ports: [{port: "10022"}]
```

After (two rules, one toPorts entry each):
```yaml
- toEndpoints: [envoy-gateway-system]
  toPorts:
  - ports: [{port: "10443"}]
    serverNames: [gitlab.internal...]
- toEndpoints: [envoy-gateway-system]
  toPorts:
  - ports: [{port: "10022"}]
```