### PR TITLE
feat(operator): add serverNames SNI filtering to FQDNAllowlist egress rules (0.4.56)

### DIFF
--- a/charts/workbench-operator/Chart.yaml
+++ b/charts/workbench-operator/Chart.yaml
@@ -22,9 +22,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.55
+version: 0.4.56
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.55"
+appVersion: "0.4.56"

--- a/charts/workbench-operator/values.yaml
+++ b/charts/workbench-operator/values.yaml
@@ -82,7 +82,7 @@ controllerManager:
         - ALL
     image:
       repository: harbor.build.chorus-tre.local/chorus/workbench-operator
-      tag: 0.4.55
+      tag: 0.4.56
     resources:
       limits:
         cpu: 500m

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
   - name: controller
     newName: harbor.chorus-tre.local/chorus/workbench-operator
-    newTag: 0.4.55
+    newTag: 0.4.56

--- a/internal/controller/network_policy.go
+++ b/internal/controller/network_policy.go
@@ -310,10 +310,29 @@ func buildNetworkPolicy(workspace defaultv1alpha1.Workspace, internalServices []
 			"toPorts": httpPortRules(),
 		})
 	case defaultv1alpha1.NetworkPolicyFQDNAllowlist:
-		// Allow only the specified FQDNs on HTTP/HTTPS.
+		// Port 443: allow only the specified FQDNs via SNI inspection (serverNames).
+		// This closes the CDN/shared-IP loophole: toFQDNs generates CIDRs from DNS
+		// responses, but multiple domains can share the same CDN IP. serverNames ensures
+		// only the explicitly allowed hostnames are reachable, even if the destination IP
+		// is shared with other domains.
+		fqdnSelectors := toFQDNSelectors(workspace.Spec.AllowedFQDNs)
 		egressRules = append(egressRules, map[string]any{
-			"toFQDNs": toFQDNSelectors(workspace.Spec.AllowedFQDNs),
-			"toPorts": httpPortRules(),
+			"toFQDNs": fqdnSelectors,
+			"toPorts": []map[string]any{
+				{
+					"ports":       []map[string]any{{"port": "443", "protocol": "TCP"}},
+					"serverNames": toServerNames(workspace.Spec.AllowedFQDNs),
+				},
+			},
+		})
+		// Port 80: allow HTTP without SNI filtering (no SNI available on plain HTTP).
+		egressRules = append(egressRules, map[string]any{
+			"toFQDNs": fqdnSelectors,
+			"toPorts": []map[string]any{
+				{
+					"ports": []map[string]any{{"port": "80", "protocol": "TCP"}},
+				},
+			},
 		})
 	default:
 		// Airgapped: no external traffic beyond kube-dns and intra-namespace.
@@ -363,22 +382,12 @@ func buildNetworkPolicy(workspace defaultv1alpha1.Workspace, internalServices []
 
 // internalServiceFQDNs extracts the FQDN list from internal services for use
 // as Cilium serverNames in CNP toPorts rules (native Envoy TLS SNI filtering).
-// FQDNs are normalized (lowercased, trimmed), deduplicated, and empty entries are skipped.
 func internalServiceFQDNs(services []InternalService) []string {
-	seen := map[string]struct{}{}
-	fqdns := make([]string, 0, len(services))
+	entries := make([]string, 0, len(services))
 	for _, svc := range services {
-		n := normalizeFQDNEntry(svc.FQDN)
-		if n == "" {
-			continue
-		}
-		if _, exists := seen[n]; exists {
-			continue
-		}
-		seen[n] = struct{}{}
-		fqdns = append(fqdns, n)
+		entries = append(entries, svc.FQDN)
 	}
-	return fqdns
+	return toServerNames(entries)
 }
 
 // internalServicePorts returns the deduplicated union of all ports declared across
@@ -425,6 +434,27 @@ func buildToPorts(tlsPorts, nonTLSPorts []string, fqdns []string, remapFn func(s
 		toPorts = append(toPorts, map[string]any{"ports": ports})
 	}
 	return toPorts
+}
+
+// toServerNames normalizes and deduplicates FQDN entries for use as Cilium serverNames
+// (native Envoy TLS SNI filtering). Wildcard patterns (e.g. *.chorus-tre.ch) are passed
+// through as-is — Cilium serverNames supports the same wildcard syntax as toFQDNs matchPattern.
+// Used by both internal service rules and FQDNAllowlist rules.
+func toServerNames(entries []string) []string {
+	seen := map[string]struct{}{}
+	var names []string
+	for _, entry := range entries {
+		entry = normalizeFQDNEntry(entry)
+		if entry == "" {
+			continue
+		}
+		if _, exists := seen[entry]; exists {
+			continue
+		}
+		seen[entry] = struct{}{}
+		names = append(names, entry)
+	}
+	return names
 }
 
 // isTLSPort reports whether a port carries TLS traffic and should use serverNames

--- a/internal/controller/network_policy.go
+++ b/internal/controller/network_policy.go
@@ -315,25 +315,27 @@ func buildNetworkPolicy(workspace defaultv1alpha1.Workspace, internalServices []
 		// responses, but multiple domains can share the same CDN IP. serverNames ensures
 		// only the explicitly allowed hostnames are reachable, even if the destination IP
 		// is shared with other domains.
-		fqdnSelectors := toFQDNSelectors(workspace.Spec.AllowedFQDNs)
-		egressRules = append(egressRules, map[string]any{
-			"toFQDNs": fqdnSelectors,
-			"toPorts": []map[string]any{
-				{
-					"ports":       []map[string]any{{"port": "443", "protocol": "TCP"}},
-					"serverNames": toServerNames(workspace.Spec.AllowedFQDNs),
+		if len(workspace.Spec.AllowedFQDNs) > 0 {
+			fqdnSelectors := toFQDNSelectors(workspace.Spec.AllowedFQDNs)
+			egressRules = append(egressRules, map[string]any{
+				"toFQDNs": fqdnSelectors,
+				"toPorts": []map[string]any{
+					{
+						"ports":       []map[string]any{{"port": "443", "protocol": "TCP"}},
+						"serverNames": toServerNames(workspace.Spec.AllowedFQDNs),
+					},
 				},
-			},
-		})
-		// Port 80: allow HTTP without SNI filtering (no SNI available on plain HTTP).
-		egressRules = append(egressRules, map[string]any{
-			"toFQDNs": fqdnSelectors,
-			"toPorts": []map[string]any{
-				{
-					"ports": []map[string]any{{"port": "80", "protocol": "TCP"}},
+			})
+			// Port 80: allow HTTP without SNI filtering (no SNI available on plain HTTP).
+			egressRules = append(egressRules, map[string]any{
+				"toFQDNs": fqdnSelectors,
+				"toPorts": []map[string]any{
+					{
+						"ports": []map[string]any{{"port": "80", "protocol": "TCP"}},
+					},
 				},
-			},
-		})
+			})
+		}
 	default:
 		// Airgapped: no external traffic beyond kube-dns and intra-namespace.
 	}

--- a/internal/controller/network_policy.go
+++ b/internal/controller/network_policy.go
@@ -442,7 +442,7 @@ func buildToPorts(tlsPorts, nonTLSPorts []string, fqdns []string, remapFn func(s
 // Used by both internal service rules and FQDNAllowlist rules.
 func toServerNames(entries []string) []string {
 	seen := map[string]struct{}{}
-	var names []string
+	names := make([]string, 0, len(entries))
 	for _, entry := range entries {
 		entry = normalizeFQDNEntry(entry)
 		if entry == "" {

--- a/internal/controller/network_policy_test.go
+++ b/internal/controller/network_policy_test.go
@@ -89,18 +89,29 @@ var _ = Describe("buildNetworkPolicy", func() {
 		Expect(err).NotTo(HaveOccurred())
 		spec := cnp.Object["spec"].(map[string]any)
 		egress := spec["egress"].([]map[string]any)
-		Expect(egress).To(HaveLen(4))
+		// 3 base + 1 FQDN/443 (with serverNames) + 1 FQDN/80 (without)
+		Expect(egress).To(HaveLen(5))
 
-		fqdnRule := egress[3]
-		toFQDNs := fqdnRule["toFQDNs"].([]map[string]any)
+		// Port 443 rule with serverNames SNI filtering
+		httpsRule := egress[3]
+		toFQDNs := httpsRule["toFQDNs"].([]map[string]any)
 		Expect(toFQDNs).To(ContainElement(HaveKeyWithValue("matchName", "example.com")))
 		Expect(toFQDNs).To(ContainElement(HaveKeyWithValue("matchPattern", "*.corp.internal")))
+		httpsToPorts := httpsRule["toPorts"].([]map[string]any)
+		Expect(httpsToPorts).To(HaveLen(1))
+		Expect(httpsToPorts[0]["ports"].([]map[string]any)).To(ContainElement(HaveKeyWithValue("port", "443")))
+		Expect(httpsToPorts[0]).To(HaveKey("serverNames"))
+		serverNames := httpsToPorts[0]["serverNames"].([]string)
+		Expect(serverNames).To(ContainElement("example.com"))
+		Expect(serverNames).To(ContainElement("*.corp.internal"))
 
-		toPorts := fqdnRule["toPorts"].([]map[string]any)
-		Expect(toPorts).To(HaveLen(1))
-		ports := toPorts[0]["ports"].([]map[string]any)
-		Expect(ports).To(ContainElement(HaveKeyWithValue("port", "80")))
-		Expect(ports).To(ContainElement(HaveKeyWithValue("port", "443")))
+		// Port 80 rule without serverNames
+		httpRule := egress[4]
+		Expect(httpRule["toFQDNs"].([]map[string]any)).To(ContainElement(HaveKeyWithValue("matchName", "example.com")))
+		httpToPorts := httpRule["toPorts"].([]map[string]any)
+		Expect(httpToPorts).To(HaveLen(1))
+		Expect(httpToPorts[0]["ports"].([]map[string]any)).To(ContainElement(HaveKeyWithValue("port", "80")))
+		Expect(httpToPorts[0]).NotTo(HaveKey("serverNames"))
 	})
 
 	It("allows full internet on HTTP/HTTPS when Open and no FQDNs specified", func() {
@@ -135,11 +146,14 @@ var _ = Describe("buildNetworkPolicy", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		egress := cnp.Object["spec"].(map[string]any)["egress"].([]map[string]any)
-		// 3 base + 1 FQDN rule (even though toFQDNs is nil)
-		Expect(egress).To(HaveLen(4))
-		fqdnRule := egress[3]
-		Expect(fqdnRule).To(HaveKey("toFQDNs"))
-		Expect(fqdnRule["toFQDNs"]).To(BeNil())
+		// 3 base + 1 FQDN/443 + 1 FQDN/80 (even though toFQDNs is nil)
+		Expect(egress).To(HaveLen(5))
+		httpsRule := egress[3]
+		Expect(httpsRule).To(HaveKey("toFQDNs"))
+		Expect(httpsRule["toFQDNs"]).To(BeNil())
+		httpRule := egress[4]
+		Expect(httpRule).To(HaveKey("toFQDNs"))
+		Expect(httpRule["toFQDNs"]).To(BeNil())
 	})
 
 	It("returns an error when called with invalid FQDNs", func() {
@@ -269,14 +283,14 @@ var _ = Describe("buildNetworkPolicy with internal services", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		egress := cnp.Object["spec"].(map[string]any)["egress"].([]map[string]any)
-		// 3 base + 1 ingress-nginx + 1 allowlist = 5
-		Expect(egress).To(HaveLen(5))
+		// 3 base + 1 ingress-nginx + 2 allowlist (443 + 80) = 6
+		Expect(egress).To(HaveLen(6))
 
 		ingressNginxRule := egress[3]
 		toEndpoints := ingressNginxRule["toEndpoints"].([]map[string]any)
 		Expect(toEndpoints[0]["matchLabels"]).To(HaveKeyWithValue("k8s:io.kubernetes.pod.namespace", "ingress-nginx"))
 
-		// Verify the FQDN allowlist rule at [4] is still correct
+		// Verify the FQDN allowlist HTTPS rule at [4]
 		allowlistRule := egress[4]
 		toFQDNs := allowlistRule["toFQDNs"].([]map[string]any)
 		Expect(toFQDNs).To(ContainElement(HaveKeyWithValue("matchName", "example.com")))

--- a/internal/controller/network_policy_test.go
+++ b/internal/controller/network_policy_test.go
@@ -146,14 +146,8 @@ var _ = Describe("buildNetworkPolicy", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		egress := cnp.Object["spec"].(map[string]any)["egress"].([]map[string]any)
-		// 3 base + 1 FQDN/443 + 1 FQDN/80 (even though toFQDNs is nil)
-		Expect(egress).To(HaveLen(5))
-		httpsRule := egress[3]
-		Expect(httpsRule).To(HaveKey("toFQDNs"))
-		Expect(httpsRule["toFQDNs"]).To(BeNil())
-		httpRule := egress[4]
-		Expect(httpRule).To(HaveKey("toFQDNs"))
-		Expect(httpRule["toFQDNs"]).To(BeNil())
+		// 3 base only — no FQDN rules emitted when AllowedFQDNs is empty
+		Expect(egress).To(HaveLen(3))
 	})
 
 	It("returns an error when called with invalid FQDNs", func() {

--- a/internal/controller/workspace_controller_test.go
+++ b/internal/controller/workspace_controller_test.go
@@ -247,7 +247,7 @@ var _ = Describe("WorkspaceReconciler", func() {
 			spec, _, _ := unstructured.NestedFieldCopy(cnp.Object, "spec")
 			specMap := spec.(map[string]any)
 			egress := specMap["egress"].([]any)
-			Expect(egress).To(HaveLen(4)) // kube-dns + intra-ns endpoints + intra-ns services + FQDN
+			Expect(egress).To(HaveLen(5)) // kube-dns + intra-ns endpoints + intra-ns services + FQDN/443 + FQDN/80
 
 			// Verify condition
 			updated := &defaultv1alpha1.Workspace{}


### PR DESCRIPTION
## Add serverNames SNI filtering to FQDNAllowlist mode

In `FQDNAllowlist` mode, Cilium `toFQDNs` generates CIDR rules from DNS responses. On CDNs and shared hosting, multiple domains can share the same IP. A workspace pod allowed to reach `github.com` could also reach any other domain on the same CDN IP, because Cilium only enforces the resolved CIDR, not the actual hostname in the TLS connection.

This adds `serverNames` to the port 443 egress rule in `FQDNAllowlist` mode. Cilium's native TLS inspector checks the ClientHello SNI and blocks connections where the SNI doesn't match an allowed entry — even if the destination IP is in an allowed CIDR.

- Split FQDNAllowlist egress into two rules: port 443 (with `serverNames` SNI filtering) and port 80 (without — HTTP has no SNI)
- Add `toServerNames` helper that normalizes and deduplicates FQDN entries for the `serverNames` field; supports wildcards (e.g. `*.chorus-tre.ch`) which Cilium serverNames handles natively
- Refactor `internalServiceFQDNs` to reuse `toServerNames` instead of duplicating normalization logic
- Cilium deduplicates `toFQDNs` selectors internally, so splitting into two rules with the same `toFQDNs` causes no duplicate DNS entries