### PR TITLE
feat(operator): restrict workspace egress to named Envoy Gateway (0.4.57)

### DIFF
--- a/charts/workbench-operator/Chart.yaml
+++ b/charts/workbench-operator/Chart.yaml
@@ -22,9 +22,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.56
+version: 0.4.57
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.56"
+appVersion: "0.4.57"

--- a/charts/workbench-operator/templates/deployment.yaml
+++ b/charts/workbench-operator/templates/deployment.yaml
@@ -41,6 +41,9 @@ spec:
         {{- range .Values.networkPolicy.envoyGatewayNamespaces }}
         - --envoy-gateway-namespace={{ . }}
         {{- end }}
+        {{- if .Values.networkPolicy.envoyGatewayName }}
+        - --envoy-gateway-name={{ .Values.networkPolicy.envoyGatewayName }}
+        {{- end }}
         - --workbench-priority-class-name={{ .Values.workbench.priorityClassName }}
         - --application-priority-class-name={{ .Values.application.priorityClassName }}
         {{- if .Values.licenseSecretName }}

--- a/charts/workbench-operator/values.yaml
+++ b/charts/workbench-operator/values.yaml
@@ -33,6 +33,8 @@ networkPolicy:
   # Uses the gateway.envoyproxy.io/owning-gateway-name label.
   # When set, workspace pods can only reach this gateway, not other gateways
   # in the same namespace (e.g. chorus-external-gateway).
+  # Must match an existing Gateway resource — mismatches silently block all workspace
+  # egress to Envoy with no obvious error signal.
   # Empty = all Envoy pods in the namespace (backwards compatible).
   envoyGatewayName: "chorus-internal-gateway"
 

--- a/charts/workbench-operator/values.yaml
+++ b/charts/workbench-operator/values.yaml
@@ -34,7 +34,7 @@ networkPolicy:
   # When set, workspace pods can only reach this gateway, not other gateways
   # in the same namespace (e.g. chorus-external-gateway).
   # Empty = all Envoy pods in the namespace (backwards compatible).
-  envoyGatewayName: ""
+  envoyGatewayName: "chorus-internal-gateway"
 
 # Storage configuration
 storage:

--- a/charts/workbench-operator/values.yaml
+++ b/charts/workbench-operator/values.yaml
@@ -29,6 +29,12 @@ networkPolicy:
   # Namespaces listed here get the remapped port in their CNP rule.
   envoyGatewayNamespaces:
     - envoy-gateway-system
+  # Restrict workspace egress to only the named Envoy Gateway's pods.
+  # Uses the gateway.envoyproxy.io/owning-gateway-name label.
+  # When set, workspace pods can only reach this gateway, not other gateways
+  # in the same namespace (e.g. chorus-external-gateway).
+  # Empty = all Envoy pods in the namespace (backwards compatible).
+  envoyGatewayName: ""
 
 # Storage configuration
 storage:
@@ -82,7 +88,7 @@ controllerManager:
         - ALL
     image:
       repository: harbor.build.chorus-tre.local/chorus/workbench-operator
-      tag: 0.4.56
+      tag: 0.4.57
     resources:
       limits:
         cpu: 500m

--- a/charts/workbench-operator/values.yaml
+++ b/charts/workbench-operator/values.yaml
@@ -33,8 +33,8 @@ networkPolicy:
   # Uses the gateway.envoyproxy.io/owning-gateway-name label.
   # When set, workspace pods can only reach this gateway, not other gateways
   # in the same namespace (e.g. chorus-external-gateway).
-  # Must match an existing Gateway resource — mismatches silently block all workspace
-  # egress to Envoy with no obvious error signal.
+  # Must match the chorus-gateway chart's internal.gateway.name value — mismatches
+  # silently block all workspace egress to Envoy with no obvious error signal.
   # Empty = all Envoy pods in the namespace (backwards compatible).
   envoyGatewayName: "chorus-internal-gateway"
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -209,9 +209,7 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	if envoyGatewayName != "" {
-		setupLog.Info("restricting workspace egress to named Envoy Gateway", "envoyGatewayName", envoyGatewayName)
-	}
+	setupLog.Info("envoy gateway configuration", "envoyGatewayNamespaces", resolvedEnvoy, "envoyGatewayName", envoyGatewayName)
 
 	// Log local storage configuration with safety warning
 	if localStorageEnabled {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -209,6 +209,9 @@ func main() {
 			os.Exit(1)
 		}
 	}
+	if envoyGatewayName != "" {
+		setupLog.Info("restricting workspace egress to named Envoy Gateway", "envoyGatewayName", envoyGatewayName)
+	}
 
 	// Log local storage configuration with safety warning
 	if localStorageEnabled {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -150,6 +150,7 @@ func main() {
 	allowedIngressNamespaces := stringSliceFlag{}
 	allowedEgressNamespaces := stringSliceFlag{}
 	envoyGatewayNamespaces := stringSliceFlag{}
+	var envoyGatewayName string
 	pvcLabels := labelFlag{}
 	globalInternalServices := internalServiceFlag{}
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metric endpoint binds to. "+
@@ -188,6 +189,7 @@ func main() {
 	flag.Var(&allowedIngressNamespaces, "allowed-ingress-namespace", "Namespace allowed to initiate connections into workspace pods (can be repeated, default: backend, prometheus)")
 	flag.Var(&allowedEgressNamespaces, "allowed-egress-namespace", "Namespace that workspace pods may connect to for internal services post-DNAT (can be repeated, default: envoy-gateway-system, ingress-nginx)")
 	flag.Var(&envoyGatewayNamespaces, "envoy-gateway-namespace", "Subset of allowed-egress-namespace that runs Envoy Gateway (ports remapped: 443→10443, can be repeated, default: envoy-gateway-system)")
+	flag.StringVar(&envoyGatewayName, "envoy-gateway-name", "", "Restrict workspace egress to only Envoy pods owned by this gateway name (e.g. chorus-internal-gateway). Empty = all Envoy pods in the namespace.")
 	flag.StringVar(&licenseSecretName, "license-secret-name", "", "Name of the license Secret (empty = no license injection)")
 	opts := zap.Options{
 		Development: true,
@@ -347,6 +349,7 @@ func main() {
 			AllowedIngress:         defaultIfEmpty([]string(allowedIngressNamespaces), []string{"backend", "prometheus"}),
 			AllowedEgress:          resolvedEgress,
 			EnvoyGatewayNamespaces: resolvedEnvoy,
+			EnvoyGatewayName:       envoyGatewayName,
 		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Workspace")

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
   - name: controller
     newName: harbor.chorus-tre.local/chorus/workbench-operator
-    newTag: 0.4.56
+    newTag: 0.4.57

--- a/internal/controller/network_policy.go
+++ b/internal/controller/network_policy.go
@@ -272,7 +272,7 @@ func buildNetworkPolicy(workspace defaultv1alpha1.Workspace, internalServices []
 				// Restrict to the named internal gateway's pods when configured,
 				// preventing workspace pods from reaching other gateways (e.g. external).
 				if ns.EnvoyGatewayName != "" {
-					labels["gateway.envoyproxy.io/owning-gateway-name"] = ns.EnvoyGatewayName
+					labels["k8s:gateway.envoyproxy.io/owning-gateway-name"] = ns.EnvoyGatewayName
 				}
 				envoyEndpoints = append(envoyEndpoints, map[string]any{"matchLabels": labels})
 			} else {

--- a/internal/controller/network_policy.go
+++ b/internal/controller/network_policy.go
@@ -132,6 +132,12 @@ type NetworkPolicyNamespaces struct {
 	// Namespaces in this list get the remapped port in their CNP toPorts rule.
 	// Namespaces not in this list (e.g. ingress-nginx) use the original port.
 	EnvoyGatewayNamespaces []string
+	// EnvoyGatewayName restricts workspace egress to only the Envoy pods owned by this gateway.
+	// Uses the gateway.envoyproxy.io/owning-gateway-name label set by Envoy Gateway on each pod.
+	// When set, workspace pods can only reach the named gateway (e.g. chorus-internal-gateway),
+	// not other gateways in the same namespace (e.g. chorus-external-gateway).
+	// When empty, all Envoy pods in the namespace are reachable (backwards compatible).
+	EnvoyGatewayName string
 }
 
 // buildNetworkPolicy constructs a namespaced CiliumNetworkPolicy (unstructured)
@@ -259,15 +265,18 @@ func buildNetworkPolicy(workspace defaultv1alpha1.Workspace, internalServices []
 		var envoyEndpoints []map[string]any
 		var regularEndpoints []map[string]any
 		for _, egressNS := range ns.AllowedEgress {
-			endpoint := map[string]any{
-				"matchLabels": map[string]any{
-					"k8s:io.kubernetes.pod.namespace": egressNS,
-				},
+			labels := map[string]any{
+				"k8s:io.kubernetes.pod.namespace": egressNS,
 			}
 			if _, ok := envoyNSSet[egressNS]; ok {
-				envoyEndpoints = append(envoyEndpoints, endpoint)
+				// Restrict to the named internal gateway's pods when configured,
+				// preventing workspace pods from reaching other gateways (e.g. external).
+				if ns.EnvoyGatewayName != "" {
+					labels["gateway.envoyproxy.io/owning-gateway-name"] = ns.EnvoyGatewayName
+				}
+				envoyEndpoints = append(envoyEndpoints, map[string]any{"matchLabels": labels})
 			} else {
-				regularEndpoints = append(regularEndpoints, endpoint)
+				regularEndpoints = append(regularEndpoints, map[string]any{"matchLabels": labels})
 			}
 		}
 

--- a/internal/controller/network_policy_test.go
+++ b/internal/controller/network_policy_test.go
@@ -468,13 +468,13 @@ var _ = Describe("buildNetworkPolicy with internal services", func() {
 		// Envoy rule should have the gateway name label
 		envoyRule := egress[3]
 		toEndpoints := envoyRule["toEndpoints"].([]map[string]any)
-		Expect(toEndpoints[0]["matchLabels"]).To(HaveKeyWithValue("gateway.envoyproxy.io/owning-gateway-name", "chorus-internal-gateway"))
+		Expect(toEndpoints[0]["matchLabels"]).To(HaveKeyWithValue("k8s:gateway.envoyproxy.io/owning-gateway-name", "chorus-internal-gateway"))
 		Expect(toEndpoints[0]["matchLabels"]).To(HaveKeyWithValue("k8s:io.kubernetes.pod.namespace", "envoy-gateway-system"))
 
 		// Regular rule should NOT have the gateway name label
 		regularRule := egress[4]
 		regularEndpoints := regularRule["toEndpoints"].([]map[string]any)
-		Expect(regularEndpoints[0]["matchLabels"]).NotTo(HaveKey("gateway.envoyproxy.io/owning-gateway-name"))
+		Expect(regularEndpoints[0]["matchLabels"]).NotTo(HaveKey("k8s:gateway.envoyproxy.io/owning-gateway-name"))
 	})
 
 	It("does not add owning-gateway-name label when EnvoyGatewayName is empty", func() {
@@ -491,7 +491,7 @@ var _ = Describe("buildNetworkPolicy with internal services", func() {
 		egress := cnp.Object["spec"].(map[string]any)["egress"].([]map[string]any)
 		envoyRule := egress[3]
 		toEndpoints := envoyRule["toEndpoints"].([]map[string]any)
-		Expect(toEndpoints[0]["matchLabels"]).NotTo(HaveKey("gateway.envoyproxy.io/owning-gateway-name"))
+		Expect(toEndpoints[0]["matchLabels"]).NotTo(HaveKey("k8s:gateway.envoyproxy.io/owning-gateway-name"))
 	})
 
 })

--- a/internal/controller/network_policy_test.go
+++ b/internal/controller/network_policy_test.go
@@ -450,6 +450,50 @@ var _ = Describe("buildNetworkPolicy with internal services", func() {
 		Expect(ports).To(ContainElement(HaveKeyWithValue("port", "10443")))
 	})
 
+	It("adds owning-gateway-name label to Envoy endpoints when EnvoyGatewayName is set", func() {
+		ws := baseWorkspace(defaultv1alpha1.NetworkPolicyAirgapped)
+		namedGW := NetworkPolicyNamespaces{
+			AllowedIngress:         []string{"backend"},
+			AllowedEgress:          []string{"envoy-gateway-system", "ingress-nginx"},
+			EnvoyGatewayNamespaces: []string{"envoy-gateway-system"},
+			EnvoyGatewayName:       "chorus-internal-gateway",
+		}
+		cnp, err := buildNetworkPolicy(ws, internalSvcs, namedGW)
+		Expect(err).NotTo(HaveOccurred())
+
+		egress := cnp.Object["spec"].(map[string]any)["egress"].([]map[string]any)
+		// 3 base + 1 envoy + 1 regular = 5
+		Expect(egress).To(HaveLen(5))
+
+		// Envoy rule should have the gateway name label
+		envoyRule := egress[3]
+		toEndpoints := envoyRule["toEndpoints"].([]map[string]any)
+		Expect(toEndpoints[0]["matchLabels"]).To(HaveKeyWithValue("gateway.envoyproxy.io/owning-gateway-name", "chorus-internal-gateway"))
+		Expect(toEndpoints[0]["matchLabels"]).To(HaveKeyWithValue("k8s:io.kubernetes.pod.namespace", "envoy-gateway-system"))
+
+		// Regular rule should NOT have the gateway name label
+		regularRule := egress[4]
+		regularEndpoints := regularRule["toEndpoints"].([]map[string]any)
+		Expect(regularEndpoints[0]["matchLabels"]).NotTo(HaveKey("gateway.envoyproxy.io/owning-gateway-name"))
+	})
+
+	It("does not add owning-gateway-name label when EnvoyGatewayName is empty", func() {
+		ws := baseWorkspace(defaultv1alpha1.NetworkPolicyAirgapped)
+		noNameGW := NetworkPolicyNamespaces{
+			AllowedIngress:         []string{"backend"},
+			AllowedEgress:          []string{"envoy-gateway-system"},
+			EnvoyGatewayNamespaces: []string{"envoy-gateway-system"},
+			EnvoyGatewayName:       "",
+		}
+		cnp, err := buildNetworkPolicy(ws, internalSvcs, noNameGW)
+		Expect(err).NotTo(HaveOccurred())
+
+		egress := cnp.Object["spec"].(map[string]any)["egress"].([]map[string]any)
+		envoyRule := egress[3]
+		toEndpoints := envoyRule["toEndpoints"].([]map[string]any)
+		Expect(toEndpoints[0]["matchLabels"]).NotTo(HaveKey("gateway.envoyproxy.io/owning-gateway-name"))
+	})
+
 })
 
 var _ = Describe("envoyRemapPort", func() {


### PR DESCRIPTION
## Restrict workspace egress to internal gateway pods only

With the dual-gateway architecture (chorus-internal-gateway + chorus-external-gateway), workspace pods must only reach the internal gateway's Envoy pods, not the external gateway's.

- Add `EnvoyGatewayName` field to `NetworkPolicyNamespaces` — when set, adds `gateway.envoyproxy.io/owning-gateway-name` label to the Envoy endpoint matchLabels in workspace CNPs
- Add `--envoy-gateway-name` CLI flag and `networkPolicy.envoyGatewayName` Helm value
- Regular (non-Envoy) egress namespaces (e.g. ingress-nginx) are unaffected
