### PR TITLE
feat(operator): auto-tag + release on master merge when Chart.yaml bumps (0.4.59)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,16 @@ name: Release
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches: [master]
 
-# Harbor publish is handled by chorus-ci (Argo Events sensor) on tag push.
-# This workflow only attaches the packaged chart to the GitHub release.
+# On every merge to master, if charts/workbench-operator/Chart.yaml contains a
+# new version (no matching v<version> tag yet), this workflow:
+#   1. Creates and pushes the v<version> tag. chorus-ci's webhook-driven sensor
+#      picks it up and publishes the image + chart to Harbor.
+#   2. Packages the chart locally with the tag as --version/--app-version
+#      (matching helm-publish-template.yaml in chorus-ci).
+#   3. Creates the GitHub release with auto-generated notes and the .tgz attached.
+# If the version in Chart.yaml is unchanged, the job short-circuits.
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -15,29 +20,57 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5.0.0
+        with:
+          fetch-depth: 0
 
       - name: Set up Helm
         uses: azure/setup-helm@v4.3.1
         with:
           version: 'latest'
 
-      - name: Package chart
+      - name: Read version from Chart.yaml
+        id: v
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION=$(awk '/^version:/ {print $2}' charts/workbench-operator/Chart.yaml | tr -d '"')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Check if tag already exists
+        id: check
+        run: |
+          if git rev-parse "refs/tags/${{ steps.v.outputs.tag }}" >/dev/null 2>&1; then
+            echo "Tag ${{ steps.v.outputs.tag }} already exists, skipping release."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure git
+        if: steps.check.outputs.skip == 'false'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Create and push tag
+        if: steps.check.outputs.skip == 'false'
+        run: |
+          git tag -a "${{ steps.v.outputs.tag }}" -m "Release ${{ steps.v.outputs.tag }}"
+          git push origin "${{ steps.v.outputs.tag }}"
+
+      - name: Package chart
+        if: steps.check.outputs.skip == 'false'
+        run: |
           helm package charts/workbench-operator \
-            --version "$VERSION" \
-            --app-version "$VERSION" \
+            --version "${{ steps.v.outputs.version }}" \
+            --app-version "${{ steps.v.outputs.version }}" \
             --destination .
 
-      - name: Upload chart to GitHub release
+      - name: Create GitHub release
+        if: steps.check.outputs.skip == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          CHART_TGZ="workbench-operator-${GITHUB_REF_NAME#v}.tgz"
-          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
-            gh release upload "$GITHUB_REF_NAME" "$CHART_TGZ" --clobber
-          else
-            gh release create "$GITHUB_REF_NAME" "$CHART_TGZ" \
-              --title "$GITHUB_REF_NAME" \
-              --generate-notes
-          fi
+          gh release create "${{ steps.v.outputs.tag }}" \
+            "workbench-operator-${{ steps.v.outputs.version }}.tgz" \
+            --title "${{ steps.v.outputs.tag }}" \
+            --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,9 +32,13 @@ jobs:
         with:
           version: 'latest'
 
+      - name: Lint chart
+        run: helm lint charts/workbench-operator
+
       - name: Read and validate version across all files
         id: v
         run: |
+          set -euo pipefail
           VERSION=$(yq '.version' charts/workbench-operator/Chart.yaml)
           APPVERSION=$(yq '.appVersion' charts/workbench-operator/Chart.yaml)
           VALUES_TAG=$(yq '.controllerManager.manager.image.tag' charts/workbench-operator/values.yaml)
@@ -71,16 +75,13 @@ jobs:
         env:
           TAG: ${{ steps.v.outputs.tag }}
         run: |
+          set -euo pipefail
           if git rev-parse "refs/tags/$TAG" >/dev/null 2>&1; then
             echo "Tag $TAG already exists, skipping release."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
-
-      - name: Lint chart
-        if: steps.check.outputs.skip == 'false'
-        run: helm lint charts/workbench-operator
 
       - name: Package chart
         if: steps.check.outputs.skip == 'false'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,14 +4,18 @@ on:
   push:
     branches: [master]
 
-# On every merge to master, if charts/workbench-operator/Chart.yaml contains a
-# new version (no matching v<version> tag yet), this workflow:
-#   1. Creates and pushes the v<version> tag. chorus-ci's webhook-driven sensor
-#      picks it up and publishes the image + chart to Harbor.
-#   2. Packages the chart locally with the tag as --version/--app-version
-#      (matching helm-publish-template.yaml in chorus-ci).
-#   3. Creates the GitHub release with auto-generated notes and the .tgz attached.
-# If the version in Chart.yaml is unchanged, the job short-circuits.
+# On every merge to master:
+#   1. Validate that the four version references are in sync (Chart.yaml
+#      version + appVersion, values.yaml image.tag, kustomization.yaml newTag).
+#   2. If no v<version> tag exists yet, package the chart and atomically
+#      create tag + GitHub release (with auto-generated notes and the .tgz
+#      attached) via the Releases API. chorus-ci's webhook picks up the tag
+#      creation and publishes the image + chart to Harbor as usual.
+# If Chart.yaml was not bumped, the job short-circuits.
+#
+# Note: the .tgz becomes downloadable from the release before chorus-ci
+# finishes pushing the image to Harbor. Any install in that window will
+# retry image pulls until Harbor has the image — transient, self-healing.
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -28,49 +32,67 @@ jobs:
         with:
           version: 'latest'
 
-      - name: Read version from Chart.yaml
+      - name: Read and validate version across all files
         id: v
         run: |
-          VERSION=$(awk '/^version:/ {print $2}' charts/workbench-operator/Chart.yaml | tr -d '"')
+          VERSION=$(yq '.version' charts/workbench-operator/Chart.yaml)
+          APPVERSION=$(yq '.appVersion' charts/workbench-operator/Chart.yaml)
+          VALUES_TAG=$(yq '.controllerManager.manager.image.tag' charts/workbench-operator/values.yaml)
+          KUSTOMIZE_TAG=$(yq '.images[0].newTag' config/manager/kustomization.yaml)
+          echo "Chart.yaml version        = $VERSION"
+          echo "Chart.yaml appVersion     = $APPVERSION"
+          echo "values.yaml image.tag     = $VALUES_TAG"
+          echo "kustomization.yaml newTag = $KUSTOMIZE_TAG"
+          mismatch=0
+          if [ "$APPVERSION" != "$VERSION" ]; then
+            echo "::error::Chart.yaml appVersion ($APPVERSION) does not match version ($VERSION)"
+            mismatch=1
+          fi
+          if [ "$VALUES_TAG" != "$VERSION" ]; then
+            echo "::error::values.yaml image.tag ($VALUES_TAG) does not match Chart.yaml version ($VERSION)"
+            mismatch=1
+          fi
+          if [ "$KUSTOMIZE_TAG" != "$VERSION" ]; then
+            echo "::error::kustomization.yaml newTag ($KUSTOMIZE_TAG) does not match Chart.yaml version ($VERSION)"
+            mismatch=1
+          fi
+          if [ "$mismatch" = "1" ]; then
+            exit 1
+          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Check if tag already exists
         id: check
+        env:
+          TAG: ${{ steps.v.outputs.tag }}
         run: |
-          if git rev-parse "refs/tags/${{ steps.v.outputs.tag }}" >/dev/null 2>&1; then
-            echo "Tag ${{ steps.v.outputs.tag }} already exists, skipping release."
+          if git rev-parse "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists, skipping release."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Configure git
-        if: steps.check.outputs.skip == 'false'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-      - name: Create and push tag
-        if: steps.check.outputs.skip == 'false'
-        run: |
-          git tag -a "${{ steps.v.outputs.tag }}" -m "Release ${{ steps.v.outputs.tag }}"
-          git push origin "${{ steps.v.outputs.tag }}"
-
       - name: Package chart
         if: steps.check.outputs.skip == 'false'
+        env:
+          VERSION: ${{ steps.v.outputs.version }}
         run: |
           helm package charts/workbench-operator \
-            --version "${{ steps.v.outputs.version }}" \
-            --app-version "${{ steps.v.outputs.version }}" \
+            --version "$VERSION" \
+            --app-version "$VERSION" \
             --destination .
 
-      - name: Create GitHub release
+      - name: Create tag + release atomically, upload chart
         if: steps.check.outputs.skip == 'false'
         env:
+          TAG: ${{ steps.v.outputs.tag }}
+          VERSION: ${{ steps.v.outputs.version }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "${{ steps.v.outputs.tag }}" \
-            "workbench-operator-${{ steps.v.outputs.version }}.tgz" \
-            --title "${{ steps.v.outputs.tag }}" \
+          gh release create "$TAG" \
+            "workbench-operator-${VERSION}.tgz" \
+            --title "$TAG" \
+            --target "$GITHUB_SHA" \
             --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,11 +38,15 @@ jobs:
           VERSION=$(yq '.version' charts/workbench-operator/Chart.yaml)
           APPVERSION=$(yq '.appVersion' charts/workbench-operator/Chart.yaml)
           VALUES_TAG=$(yq '.controllerManager.manager.image.tag' charts/workbench-operator/values.yaml)
-          KUSTOMIZE_TAG=$(yq '.images[0].newTag' config/manager/kustomization.yaml)
+          KUSTOMIZE_TAG=$(yq '.images[] | select(.name == "controller") | .newTag' config/manager/kustomization.yaml)
           echo "Chart.yaml version        = $VERSION"
           echo "Chart.yaml appVersion     = $APPVERSION"
           echo "values.yaml image.tag     = $VALUES_TAG"
           echo "kustomization.yaml newTag = $KUSTOMIZE_TAG"
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Chart.yaml version '$VERSION' is not in the expected x.y.z format"
+            exit 1
+          fi
           mismatch=0
           if [ "$APPVERSION" != "$VERSION" ]; then
             echo "::error::Chart.yaml appVersion ($APPVERSION) does not match version ($VERSION)"
@@ -73,6 +77,10 @@ jobs:
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Lint chart
+        if: steps.check.outputs.skip == 'false'
+        run: helm lint charts/workbench-operator
 
       - name: Package chart
         if: steps.check.outputs.skip == 'false'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+# Harbor publish is handled by chorus-ci (Argo Events sensor) on tag push.
+# This workflow only attaches the packaged chart to the GitHub release.
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5.0.0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4.3.1
+        with:
+          version: 'latest'
+
+      - name: Package chart
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          helm package charts/workbench-operator \
+            --version "$VERSION" \
+            --app-version "$VERSION" \
+            --destination .
+
+      - name: Upload chart to GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          CHART_TGZ="workbench-operator-${GITHUB_REF_NAME#v}.tgz"
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            gh release upload "$GITHUB_REF_NAME" "$CHART_TGZ" --clobber
+          else
+            gh release create "$GITHUB_REF_NAME" "$CHART_TGZ" \
+              --title "$GITHUB_REF_NAME" \
+              --generate-notes
+          fi

--- a/charts/workbench-operator/Chart.yaml
+++ b/charts/workbench-operator/Chart.yaml
@@ -22,9 +22,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.58
+version: 0.4.59
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.58"
+appVersion: "0.4.59"

--- a/charts/workbench-operator/values.yaml
+++ b/charts/workbench-operator/values.yaml
@@ -82,7 +82,7 @@ controllerManager:
         - ALL
     image:
       repository: harbor.build.chorus-tre.local/chorus/workbench-operator
-      tag: 0.4.58
+      tag: 0.4.59
     resources:
       limits:
         cpu: 500m

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
   - name: controller
     newName: harbor.chorus-tre.local/chorus/workbench-operator
-    newTag: 0.4.58
+    newTag: 0.4.59


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release.yml` to automate the release flow. On every merge to `master`, the workflow:

1. Runs `helm lint charts/workbench-operator` so chart regressions are caught on the merge they land in, not on the next version bump.
2. Reads the chart version from `charts/workbench-operator/Chart.yaml` and validates it matches `x.y.z`.
3. Validates the four version references agree: `Chart.yaml` `version` + `appVersion`, `values.yaml` `controllerManager.manager.image.tag`, and `config/manager/kustomization.yaml` `images[name=controller].newTag`. Mismatch fails the workflow loudly.
4. If the `v<version>` tag already exists, short-circuits (the PR didn't bump the version — nothing to release).
5. Otherwise packages the chart with the tag as `--version` / `--app-version`, and atomically creates the tag + GitHub release via the Releases API with the `.tgz` attached and auto-generated notes.

Also bumps the four version values to `0.4.59` to validate the flow end-to-end on first merge.

## Notes

- Harbor publishing is unchanged — `chorus-ci`'s `build-workbench-operator-sensor` still picks up the tag creation webhook and pushes the image + chart to Harbor. The locally-packaged `.tgz` uses the same `--version` / `--app-version` override, so it matches the version of what chorus-ci pushes.
- `gh release create --target $GITHUB_SHA` creates tag + release in one API call, so a partial failure can't leave an orphan tag that blocks future runs.
- All interpolation of user-influenced values (`version`, `tag`) goes through `env:` and is referenced as shell variables, so a malformed/malicious Chart.yaml can't inject commands into the workflow shell.
- Parsing uses `yq`, which handles any YAML quoting style.
- Multi-line `run:` blocks set `-euo pipefail` explicitly (GHA's default bash already has `-e` and `-o pipefail`; `-u` is the extra protection, and explicit flags insulate from any future change to the runner defaults).
- Tag pushes made with the default `GITHUB_TOKEN` do not re-trigger GitHub Actions workflows (loop prevention). chorus-ci listens via webhook, not Actions, so it is unaffected.
- No additional secrets required beyond the default `GITHUB_TOKEN`.
- The workflow only takes effect for merges to `master` after this PR lands.

## Known tradeoff

The `.tgz` becomes downloadable from the GitHub release a few seconds before chorus-ci finishes publishing the image to Harbor. Any `helm install` in that window retries image pulls until the image is present — transient and self-healing.

## Review history

- Initial: `on: push tags: v*` + upload-to-existing-release. Reworked to `on: push branches: [master]` with auto-tag after discussion.
- Security hardening from PR review: env-passed values, atomic tag+release, four-file consistency check, yq parser.
- Minor follow-ups: kustomize select by name, `helm lint`, `x.y.z` regex check.
- Final follow-ups: lint runs on every master push (not only on release path), and `set -euo pipefail` added to multi-line scripts.